### PR TITLE
Copy on write list

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+trim_trailing_whitespace = true

--- a/thread-context/src/main/java/com/github/threadcontext/MutableContextSupplier.java
+++ b/thread-context/src/main/java/com/github/threadcontext/MutableContextSupplier.java
@@ -1,6 +1,6 @@
 package com.github.threadcontext;
 
-import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -9,7 +9,15 @@ public class MutableContextSupplier implements Supplier<Context> {
     public final List<Supplier<Context>> suppliers;
 
     public MutableContextSupplier() {
-        suppliers = new ArrayList<>();
+        // Use CopyOnWriteArray to prevent ConcurrentModificationException
+        // if something tries to consume the suppplier while another thread is
+        // adding new suppliers.
+        //
+        // This shouldn't hurt performance too  much, since the list of suppliers should be
+        // small, and setting suppliers should just be done once early in the lifecycle of the context.
+        // And this prevents us to need to synchronize whenever we read or iterate over the suppliers,
+        // which will be much more common than writing to the list.
+        suppliers = new CopyOnWriteArrayList<>();
     }
 
     public Context get() {


### PR DESCRIPTION
Make MutableContextSupplier thread safe
    
    Make it so that mutating the MutableContextSupplier (which is used by Context.DEFAULT), doesn't
    cause race conditions with reading the supplied value.